### PR TITLE
Use bash syntax instead of Makefile syntax

### DIFF
--- a/initiate
+++ b/initiate
@@ -7,16 +7,16 @@ set -eo pipefail
 # environment variable (base64 encoded). This should come from a user who ONLY
 # has permission to read from the repositories a project needs.
 deploy-key-setup() {
-  @if [[ $$DEPLOY_SSH_PRIVATE_KEY == "" ]]; then
+  if [[ $DEPLOY_SSH_PRIVATE_KEY == "" ]]; then
     echo 'No deploy key found, skipping setup';
     exit 1;
   fi
 
-  @mkdir -p ~/.ssh
-  @echo $$DEPLOY_SSH_PRIVATE_KEY | base64 --decode > ~/.ssh/shyp-deploy-key
-  @chmod 400 ~/.ssh/shyp-deploy-key
-  -mv -f ~/.ssh/config ~/.ssh/config.backup
-  @echo -e "Host github.com\n"\
+  mkdir -p ~/.ssh
+  echo $DEPLOY_SSH_PRIVATE_KEY | base64 --decode > ~/.ssh/shyp-deploy-key
+  chmod 400 ~/.ssh/shyp-deploy-key
+  mv -f ~/.ssh/config ~/.ssh/config.backup || true
+  echo -e "Host github.com\n"\
          " IdentityFile ~/.ssh/shyp-deploy-key\n"\
          " IdentitiesOnly yes\n"\
          " UserKnownHostsFile=/dev/null\n"\
@@ -24,18 +24,18 @@ deploy-key-setup() {
 }
 
 deploy-key-teardown() {
-	@if [[ $$DEPLOY_SSH_PRIVATE_KEY == "" ]]; then
+	if [[ $DEPLOY_SSH_PRIVATE_KEY == "" ]]; then
     echo 'No deploy key found, skipping teardown';
     exit 1;
   fi
 
-  -rm -f ~/.ssh/shyp-deploy-key
-  -rm -f ~/.ssh/config
-  -mv -f ~/.ssh/config.backup ~/.ssh/config
+  rm -f ~/.ssh/shyp-deploy-key || true
+  rm -f ~/.ssh/config || true
+  mv -f ~/.ssh/config.backup ~/.ssh/config || true
 }
 
 main() {
-  @if [[ $1 == "setup" ]]; then
+  if [[ $1 == "setup" ]]; then
     deploy-key-setup
   else
     deploy-key-teardown

--- a/initiate
+++ b/initiate
@@ -24,7 +24,7 @@ deploy-key-setup() {
 }
 
 deploy-key-teardown() {
-	if [[ $DEPLOY_SSH_PRIVATE_KEY == "" ]]; then
+  if [[ $DEPLOY_SSH_PRIVATE_KEY == "" ]]; then
     echo 'No deploy key found, skipping teardown';
     exit 1;
   fi


### PR DESCRIPTION
Tested locally:

```
λ ./initiate setup
mv: rename /Users/dylan/.ssh/config to /Users/dylan/.ssh/config.backup: No such file or directory

λ ./initiate teardown
mv: rename /Users/dylan/.ssh/config.backup to /Users/dylan/.ssh/config: No such file or directory
```

Note that the exit codes for both of those commands was 0 despite the error
message. If you think we should suppress that, I can do that too.

---

Also - was there any discussion about maybe introducing this to the `shyp` CLI as well / instead? I imagine we might have other shared scripts (like npm publishing) that we want to deduplicate.
