### PR TITLE
Add more scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: patch minor deploy
+
+patch:
+	./bin/patch
+
+minor:
+	./bin/minor
+
+deploy:
+	./bin/deploy

--- a/README.md
+++ b/README.md
@@ -2,35 +2,49 @@
 
 The Shyp toolkit serves as home to various scripts that multiple Shyp apps use throughout the deployment pipeline
 
-## Setup Node app with private git dependencies
+## How to work with private git dependencies
 
 If your app uses any private git dependencies, heroku `npm install` will fail. To get around that, you would need to tap into heroku's build process so that right before `npm install` is called, you provide heroku with a private ssh key that it can use to access your repos.
 
 Here is how you go about doing that.
 
 ### Steps
+- Create a new file called `deploy-key-runner` with the following content in the `/bin` directory
+
+```
+#!/usr/bin/env bash
+set -eo pipefail
+
+prechecks() {
+  local bin_directory=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+  pushd "$bin_directory"
+    if [ ! -f deploy-key ]; then
+      curl --remote-name https://raw.githubusercontent.com/Shyp/shyp-toolkit/{release_version}/bin/deploy-key
+      chmod +x deploy-key
+    fi
+  popd
+}
+
+main() {
+  prechecks
+
+  if [[ $1 == "setup" ]]; then
+    ./bin/deploy-key setup
+  else
+    ./bin/deploy-key teardown
+  fi
+}
+
+main "$@"
+```
+
 - In your `package.json`, add the following (This tells heroku to run the `preinstall` script before `npm install` and the `postinstall` after `npm install`)
+
 ```
 "scripts": {
-    "preinstall": "make deploy-key-setup || true",
-    "postinstall": "make deploy-key-teardown || true"
-  }
-
-"dependencies": {
-  ...
-  "shyp-toolkit": "Shyp/shyp-toolkit#v1.0.0",
-  ...
+    "preinstall": "make deploy-key-runner setup || true",
+    "postinstall": "make deploy-key-runner teardown || true"
 }
-```
-
-- In your `Makefile`, add the following
-
-```
-deploy-key-setup:
-  $$(npm bin)/deploy-key setup
-
-deploy-key-teardown:
-  $$(npm bin)/deploy-key teardown
 ```
 
 - Create a new machine user on Github that has read access to the private repos you need.
@@ -41,3 +55,26 @@ deploy-key-teardown:
 `heroku config:set DEPLOY_SSH_PRIVATE_KEY={BASE64_MACHINE_USER_PRIVATE_KEY} --app {APP_NAME}`
 
 Once you deploy - you should be all setup!
+
+## How to work with patch/minor/deploy
+- In your `package.json`, add the new shyp-toolkit dependency
+```
+"dependencies": {
+  ...
+  "shyp-toolkit": "Shyp/shyp-toolkit#{release_version}",
+  ...
+}
+```
+
+- In your `Makefile`, add the following
+
+```
+patch:
+	$$(npm bin)/patch
+
+minor:
+	$$(npm bin)/minor
+
+deploy:
+	$$(npm bin)/deploy
+```

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+main() {
+  if ! git diff-files --quiet ; then
+    echo "\033[91mCurrent working branch is dirty; cannot deploy. Please commit/stash your working tree \033[0m";
+    exit 1;
+  fi
+
+  # So local branches are up to date
+  git fetch origin
+  git checkout master
+
+  if ! git describe --exact-match --tags HEAD ; then
+    echo "\033[91mHEAD does not have a matching tag; aborting. Please tag this commit\033[0m";
+    exit 1;
+  fi
+
+  git checkout production
+  git pull --rebase origin production
+  git merge --ff-only master
+  git push origin production
+  git checkout develop
+}
+
+main "$@"

--- a/bin/minor
+++ b/bin/minor
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+main() {
+  # So local branches are up to date.
+  git fetch origin
+  git checkout develop
+  git pull --rebase origin develop
+  npm version minor
+  git push origin develop --follow-tags
+  git checkout master
+  git pull --rebase origin master
+  git merge --ff-only develop
+  git push origin master
+}
+
+main "$@"

--- a/bin/minor
+++ b/bin/minor
@@ -13,11 +13,12 @@ main() {
   git checkout develop
   git pull --rebase origin develop
 
-  # If current HEAD is not tagged, then create a tag for it
-  if ! git describe --exact-match --tags HEAD ; then
-    npm version minor
+  if git describe --exact-match --tags HEAD ; then
+    echo "\033[91mHEAD already has a matching tag, not creating another.\033[0m";
+    exit 1;
   fi
 
+  npm version minor
   git push origin develop --follow-tags
   git checkout master
   git pull --rebase origin master

--- a/bin/minor
+++ b/bin/minor
@@ -3,11 +3,21 @@
 set -eo pipefail
 
 main() {
+  if git status --porcelain != ""; then
+    echo 'Working directory is not clean (try `git status`), not releasing.';
+    exit 1;
+  fi
+
   # So local branches are up to date.
   git fetch origin
   git checkout develop
   git pull --rebase origin develop
-  npm version minor
+
+  # If current HEAD is not tagged, then create a tag for it
+  if ! git describe --exact-match --tags HEAD ; then
+    npm version minor
+  fi
+
   git push origin develop --follow-tags
   git checkout master
   git pull --rebase origin master

--- a/bin/patch
+++ b/bin/patch
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+main() {
+  # So local branches are up to date.
+  git fetch origin
+  git checkout develop
+  git pull --rebase origin develop
+  npm version patch
+  git push origin develop --follow-tags
+  git checkout master
+  git pull --rebase origin master
+  git merge --ff-only develop
+  git push origin master
+}
+
+main "$@"

--- a/bin/patch
+++ b/bin/patch
@@ -3,11 +3,21 @@
 set -eo pipefail
 
 main() {
+  if git status --porcelain != ""; then
+    echo 'Working directory is not clean (try `git status`), not releasing.';
+    exit 1;
+  fi
+
   # So local branches are up to date.
   git fetch origin
   git checkout develop
   git pull --rebase origin develop
-  npm version patch
+
+  # If current HEAD is not tagged, then create a tag for it
+  if ! git describe --exact-match --tags HEAD ; then
+    npm version patch
+  fi
+
   git push origin develop --follow-tags
   git checkout master
   git pull --rebase origin master

--- a/bin/patch
+++ b/bin/patch
@@ -13,11 +13,12 @@ main() {
   git checkout develop
   git pull --rebase origin develop
 
-  # If current HEAD is not tagged, then create a tag for it
-  if ! git describe --exact-match --tags HEAD ; then
-    npm version patch
+  if git describe --exact-match --tags HEAD ; then
+    echo "\033[91mHEAD already has a matching tag, not creating another.\033[0m";
+    exit 1;
   fi
 
+  npm version patch
   git push origin develop --follow-tags
   git checkout master
   git pull --rebase origin master

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Shyp <platform@shyp.com>",
   "license": "MIT",
   "bin": {
-    "deploy-key": "./bin/deploy-key"
+    "deploy-key": "./bin/deploy-key",
+    "deploy": "./bin/deploy",
+    "minor": "./bin/minor",
+    "patch": "./bin/patch"
   }
 }


### PR DESCRIPTION
This change updates the README with the correct deploy-key steps.
It also introduces patch/minor/deploy scripts pulled from `shyp_api`
It also adds the ability to go through a develop-master-production pipeline
