### PR TITLE
Write the ssh config to $HOME/.ssh/shyp-config

### DIFF
--- a/bin/deploy-key
+++ b/bin/deploy-key
@@ -13,14 +13,15 @@ deploy-key-setup() {
   fi
 
   mkdir -p ~/.ssh
-  echo $DEPLOY_SSH_PRIVATE_KEY | base64 --decode > ~/.ssh/shyp-deploy-key
-  chmod 400 ~/.ssh/shyp-deploy-key
-  mv -f ~/.ssh/config ~/.ssh/config.backup || true
-  echo -e "Host github.com\n"\
-         " IdentityFile ~/.ssh/shyp-deploy-key\n"\
-         " IdentitiesOnly yes\n"\
-         " UserKnownHostsFile=/dev/null\n"\
-         " StrictHostKeyChecking no" > ~/.ssh/config
+  pushd ~/.ssh
+    echo $DEPLOY_SSH_PRIVATE_KEY | base64 --decode > shyp-deploy-key
+    chmod 400 ~/.ssh/shyp-deploy-key
+    echo -e "Host github.com\n"\
+            " IdentityFile ~/.ssh/shyp-deploy-key\n"\
+            " IdentitiesOnly yes\n"\
+            " UserKnownHostsFile=/dev/null\n"\
+            " StrictHostKeyChecking no" > shyp-config
+  popd
 }
 
 deploy-key-teardown() {
@@ -30,8 +31,7 @@ deploy-key-teardown() {
   fi
 
   rm -f ~/.ssh/shyp-deploy-key || true
-  rm -f ~/.ssh/config || true
-  mv -f ~/.ssh/config.backup ~/.ssh/config || true
+  rm -f ~/.ssh/shyp-config || true
 }
 
 main() {


### PR DESCRIPTION
We don't need to overwrite/move .ssh/config, we can use the `GIT_SSH`
environment variable to instruct Git to use a different SSH config file. In
this case we write our SSH config file to ~/.ssh/shyp-config.

In outer repos, we'll set GIT_SSH in the install scripts.
